### PR TITLE
一度閲覧した商品を画面表示

### DIFF
--- a/app/assets/stylesheets/items.scss
+++ b/app/assets/stylesheets/items.scss
@@ -350,7 +350,7 @@ body{
         position: relative;
         width: 539px;
         margin: 11px 0 0 3px;
-        ul.rankingList{
+        ul.rankingList, ul.pickupList{
           margin: 0 0 0 -17px;
           li{
             float: left;

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -7,9 +7,7 @@ class ItemsController < ApplicationController
   def show
     # チェックした商品をsessionに保存し、チェック済商品を画面表示できるようにする
     # sessionがない場合は初期化
-    unless session[:checked_item_ids]
-      session[:checked_item_ids] = []
-    end
+    session[:checked_item_ids] = session[:checked_item_ids].present? ? session[:checked_item_ids] : []
     # sessionにチェックした商品IDを保存
     session[:checked_item_ids] << params[:id]
     @checked_items = Item.where(id: session[:checked_item_ids])

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -3,6 +3,14 @@ class ItemsController < ApplicationController
     @items = Item.includes(:shop).includes(:brand)
   end
   def show
-    @item = Item.new
+    # チェックした商品をsessionに保存し、チェック済商品を画面表示できるようにする
+    # sessionがない場合は初期化
+    unless session[:checked_items]
+      session[:checked_items] = []
+    end
+    # sessionにチェックした商品IDを保存
+    session[:checked_items] << params[:id]
+    @checked_items = session[:checked_items]
+    @item = Item.find(params[:id])
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,16 +1,18 @@
 class ItemsController < ApplicationController
   def index
     @items = Item.includes(:shop).includes(:brand)
+    # チェック済商品を画面表示
+    @checked_items = Item.where(id: session[:checked_item_ids])
   end
   def show
     # チェックした商品をsessionに保存し、チェック済商品を画面表示できるようにする
     # sessionがない場合は初期化
-    unless session[:checked_items]
-      session[:checked_items] = []
+    unless session[:checked_item_ids]
+      session[:checked_item_ids] = []
     end
     # sessionにチェックした商品IDを保存
-    session[:checked_items] << params[:id]
-    @checked_items = session[:checked_items]
+    session[:checked_item_ids] << params[:id]
+    @checked_items = Item.where(id: session[:checked_item_ids])
     @item = Item.find(params[:id])
   end
 end

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -89,7 +89,7 @@
               %h2 チェックしたアイテム
             #pickupItem.loader.pickupList.clearfix
               %ul.pickupList.clearfix
-                - unless @checked_items.blank?
+                - if @checked_items.present?
                   - @checked_items.each do |checked_item|
                     = render partial: "item", locals: { item: checked_item }
           %section#pickupShops.section.pickup

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -88,7 +88,10 @@
             .clearfix.sectionHeader
               %h2 チェックしたアイテム
             #pickupItem.loader.pickupList.clearfix
-            / /#pickupItem
+              %ul.pickupList.clearfix
+                - unless @checked_items.blank?
+                  - @checked_items.each do |checked_item|
+                    = render partial: "item", locals: { item: checked_item }
           %section#pickupShops.section.pickup
             .clearfix.sectionHeader
               %h2 チェックしたショップ


### PR DESCRIPTION
# What
詳細画面で閲覧した商品情報をセッションに記録しておき、
一覧画面にて一度閲覧した商品が見れるようにする。
# Why
ユーザの利便性向上のため。